### PR TITLE
Fix corrupted SVG image

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="256px" height="310px" viewBox="0 0 256 310" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
 	<g>


### PR DESCRIPTION
I was looking at the [plugin page](http://readme.drone.io/plugins/ecr/) and noticed the the logo wasn't rendering (at least not in Chrome). Apparently the xml declaration has to be on the first line.
