### PR TITLE
Remote graph caching

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -78,7 +78,7 @@ The Drone build environment is, by default, ephemeral meaning that you layers ar
 
 ### Graph directory caching
 
-This is the preferred method when using the `overlay` storage driver. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
+This is the preferred method when using the `overlay` or `aufs` storage drivers. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
 
 ```yaml
 publish:
@@ -96,7 +96,7 @@ cache:
     - /drone/docker
 ```
 
-NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` storage driver with this method.
+NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` or `aufs` storage driver with this method.
 
 ### Layer Caching
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -72,9 +72,35 @@ publish:
       - HTTP_PROXY=http://yourproxy.com
 ```
 
-## Layer Caching
+## Caching
 
-The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. The below example combines Drone's caching feature and Docker's `save` and `load` capabilities to cache and restore image layers between builds:
+The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching layers.
+
+### Graph directory caching
+
+This is the preferred method when using the `overlay` storage driver. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
+
+```yaml
+publish:
+  docker:
+    username: kevinbacon
+    password: pa55word
+    email: kevin.bacon@mail.com
+    repo: foo/bar
+    tag:
+      - latest
+      - "1.0.1"
+
+cache:
+  mount:
+    - /drone/docker
+```
+
+NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` storage driver with this method.
+
+### Layer Caching
+
+The below example combines Drone's caching feature and Docker's `save` and `load` capabilities to cache and restore image layers between builds:
 
 ```yaml
 publish:

--- a/DOCS.md
+++ b/DOCS.md
@@ -74,7 +74,7 @@ publish:
 
 ## Caching
 
-The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching layers.
+The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching your layers.
 
 ### Graph directory caching
 

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	go func() {
-		args := []string{"-d"}
+		args := []string{"daemon"}
 
 		if len(vargs.Storage) != 0 {
 			args = append(args, "-s", vargs.Storage)

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	go func() {
-		args := []string{"daemon"}
+		args := []string{"daemon", "-g", "/drone/docker"}
 
 		if len(vargs.Storage) != 0 {
 			args = append(args, "-s", vargs.Storage)

--- a/main.go
+++ b/main.go
@@ -270,7 +270,7 @@ func main() {
 
 	// Remove untagged images, if any
 	var outbuf bytes.Buffer
-	cmd = exec.Command("sh", "-c", "docker images | grep '^<none>' | awk '{print $3}'")
+	cmd = exec.Command("docker", "images", "-q", "-f", "dangling=true")
 	cmd.Stdout = &outbuf
 	cmd.Stderr = os.Stderr
 	trace(cmd)


### PR DESCRIPTION
This is a cherrypick of the changes made to the drone-docker-plugin to improve caching of the docker build commands.
