### PR TITLE
accept external source file

### DIFF
--- a/bin/wrap-drone-docker.sh
+++ b/bin/wrap-drone-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ex
+
 # support PLUGIN_ and ECR_ variables
 [ -n "$ECR_REGION" ] && export PLUGIN_REGION=${ECR_REGION}
 [ -n "$ECR_ACCESS_KEY" ] && export PLUGIN_ACCESS_KEY=${ECR_ACCESS_KEY}
@@ -25,7 +27,6 @@ fi
 # export AWS_SECRET_ACCESS_KEY=XXX
 # export AWS_SESSION_TOKEN=xxx
 if [ "$PLUGIN_EXTERNAL" == "true" ] && [ -n "PLUGIN_TOKEN_FILE" ]; then
-  cat ${PLUGIN_TOKEN_FILE}
   . ${PLUGIN_TOKEN_FILE}
 fi
 

--- a/bin/wrap-drone-docker.sh
+++ b/bin/wrap-drone-docker.sh
@@ -30,13 +30,8 @@ if [ "$PLUGIN_EXTERNAL" == "true" ] && [ -n "PLUGIN_TOKEN_FILE" ]; then
   . ${PLUGIN_TOKEN_FILE}
 fi
 
-# get token from aws
-aws_auth=$(aws ecr get-authorization-token --output text)
-
-# map some ecr specific variable names to their docker equivalents
-export DOCKER_USERNAME=AWS
-export DOCKER_PASSWORD=$(echo $aws_auth | cut -d ' ' -f2 | base64 -d | cut -d: -f2)
-export DOCKER_REGISTRY=$(echo $aws_auth | cut -d ' ' -f4)
+# Authenticate your Docker client to ECR registry
+aws ecr get-login --no-include-email --region ap-southeast-2|sh
 
 # invoke the docker plugin
 /bin/drone-docker "$@"

--- a/bin/wrap-drone-docker.sh
+++ b/bin/wrap-drone-docker.sh
@@ -4,6 +4,7 @@
 [ -n "$ECR_REGION" ] && export PLUGIN_REGION=${ECR_REGION}
 [ -n "$ECR_ACCESS_KEY" ] && export PLUGIN_ACCESS_KEY=${ECR_ACCESS_KEY}
 [ -n "$ECR_SECRET_KEY" ] && export PLUGIN_SECRET_KEY=${ECR_SECRET_KEY}
+[ -n "$ECR_SESSION_TOKEN" ] && export PLUGIN_SESSION_TOKEN=${ECR_SESSION_TOKEN}
 [ -n "$ECR_CREATE_REPOSITORY" ] && export PLUGIN_SECRET_KEY=${PLUGIN_CREATE_REPOSITORY}
 
 # set the region
@@ -12,6 +13,20 @@ export AWS_DEFAULT_REGION=${PLUGIN_REGION:-'us-east-1'}
 if [ -n "$PLUGIN_ACCESS_KEY" ] && [ -n "$PLUGIN_SECRET_KEY" ]; then
   export AWS_ACCESS_KEY_ID=${PLUGIN_ACCESS_KEY}
   export AWS_SECRET_ACCESS_KEY=${PLUGIN_SECRET_KEY}
+fi
+
+if [ -n "$PLUGIN_SESSION_TOKEN" ]; then
+  export AWS_ACCESS_SESSION_TOKEN=${PLUGIN_SESSION_TOKEN}
+fi
+
+# Support external AWS_ variables
+# Sample file token
+# export AWS_ACCESS_KEY_ID=XXX
+# export AWS_SECRET_ACCESS_KEY=XXX
+# export AWS_SESSION_TOKEN=xxx
+
+if [ -f ./token ];then
+  . ./token
 fi
 
 # get token from aws

--- a/bin/wrap-drone-docker.sh
+++ b/bin/wrap-drone-docker.sh
@@ -19,14 +19,14 @@ if [ -n "$PLUGIN_SESSION_TOKEN" ]; then
   export AWS_ACCESS_SESSION_TOKEN=${PLUGIN_SESSION_TOKEN}
 fi
 
-# Support external AWS_ variables
-# Sample file token
+# Support external AWS_ variables and source it.
+# Sample file of PLUGIN_TOKEN_FILE
 # export AWS_ACCESS_KEY_ID=XXX
 # export AWS_SECRET_ACCESS_KEY=XXX
 # export AWS_SESSION_TOKEN=xxx
-
-if [ -f ./token ];then
-  . ./token
+if [ "$PLUGIN_EXTERNAL" == "true" ] && [ -n "PLUGIN_TOKEN_FILE" ]; then
+  cat ${PLUGIN_TOKEN_FILE}
+  . ${PLUGIN_TOKEN_FILE}
 fi
 
 # get token from aws


### PR DESCRIPTION
With current version in Drone, 

it doesn't support to transfer the variables (`ECR_*` or `PLUGIN_*`) to next step. 
it doesn't support [Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
it doesn't support to `source file` to get external environment variables from a source file.

So I have to add below feature to drone ECR plugin:

- support `AWS_ACCESS_SESSION_TOKEN` (Temporary Security Credentials), this is optional.

Usage with this new feature

```diff
docker run --rm \
  -e PLUGIN_TAG=latest \
  -e PLUGIN_REPO=octocat/hello-world \
  -e ECR_ACCESS_KEY=N1DOBESIHFPDZBI2YBGA \
  -e ECR_SECRET_KEY=HdUp4yYnTjeDaYfH2NICMdHg0V5qHdpce1vxAySv \
+ -e ECR_SESSION_TOKEN= ZhQHiLOAV75c4TpIpy8ZWq.... \
  -e ECR_REGION=us-east-1 \
  -e ECR_CREATE_REPOSITORY=true \
  -e DRONE_COMMIT_SHA=d8dbe4d94f15fe89232e0402c6e8a0ddf21af3ab \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  --privileged \
  plugins/ecr --dry-run
```

- support external source file.

Usage with this new feature

```diff
docker run --rm \
  -e PLUGIN_TAG=latest \
  -e PLUGIN_REPO=octocat/hello-world \
+ -e PLUGIN_EXTERNAL=true \
+ -e PLUGIN_TOKEN_FILE=token \
  -e ECR_CREATE_REPOSITORY=true \
  -e DRONE_COMMIT_SHA=d8dbe4d94f15fe89232e0402c6e8a0ddf21af3ab \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  --privileged \
  plugins/ecr --dry-run
```
The file `token` can be generated from previous step.

Related pipeline sample

```diff
  ecr:
    image: plugins/ecr
    repo: octocat/hello-world
    registry: 1234567890.dkr.ecr.ap-southeast-2.amazonaws.com
    region: ap-southeast-2
    dockerfile: orig/proj-1/Dockerfile
+   external: true
+   token_file: token
```

- change aws ecr login command 

from 

    aws ecr get-authorization-token --output text

to 

    aws ecr get-login --no-include-email --region ap-southeast-2|sh